### PR TITLE
feat(overridable menu): menu can now be overridden

### DIFF
--- a/sbstr8.config.ts
+++ b/sbstr8.config.ts
@@ -1,4 +1,6 @@
 import { Config } from '@/sbstr8/lib/types/config';
+// import { faList, faRss, faHome } from '@fortawesome/free-solid-svg-icons';
+// import defaults from '@/sbstr8/lib/default';
 // import Link from '@/sbstr8/components/link';
 // import Feature from '@/sbstr8/components/feature';
 export const env = process.env.NODE_ENV;
@@ -26,5 +28,8 @@ export default config;
 
 // this export has to be here
 export const override = new WeakMap();
+// override.set(defaults.menu, [
+//   { href: config.link, icon: faHome, title: 'back' },
+// ]);
 // override.set(Link, import('./src/components/my-link'));
 // override.set(Feature, import('./src/components/my-feature'));

--- a/src/sbstr8/components/page/header.tsx
+++ b/src/sbstr8/components/page/header.tsx
@@ -5,7 +5,7 @@ import {
 } from '@/sbstr8/components/link';
 import ccn from '@sindresorhus/class-names';
 import cfg from '@/../sbstr8.config';
-import { menuLinks } from '@/sbstr8/lib/menu';
+import { menu, MenuItem } from '@/sbstr8/lib/menu';
 import useOverride from '@/sbstr8/lib/hook/server/override';
 
 export interface PageHeaderProps {
@@ -33,7 +33,7 @@ export const PageHeader = async ({
           <Link href={cfg.link}>{children}</Link>
         </span>
         <menu className="sbstr8:page-header-nav-menu">
-          {menuLinks.map(({ href, title }, i) => (
+          {menu.map(({ href, title }: MenuItem, i: number) => (
             <h1
               key={i}
               className={ccn(

--- a/src/sbstr8/lib/default.ts
+++ b/src/sbstr8/lib/default.ts
@@ -1,0 +1,24 @@
+import { faList, faRss, faHome } from '@fortawesome/free-solid-svg-icons';
+// Defaults
+
+export const defaults = {
+  menu: [
+    { href: '/', title: 'Home', icon: faHome },
+    { href: '/feed', title: 'Feed', icon: faRss },
+    { href: '/posts', title: 'Posts', icon: faList },
+  ],
+  date: {
+    created: 'Jan 01 2023',
+  },
+  dimension: {
+    thumbnail: 256,
+    primaryFeatureImageHeight: 512,
+    secondaryFeatureImageHeight: 512,
+    tertiaryFeatureImageHeight: 512,
+    logo: 32,
+  },
+  image: {
+    logo: '/media/sbstr8.svg',
+  },
+};
+export default defaults;

--- a/src/sbstr8/lib/menu.tsx
+++ b/src/sbstr8/lib/menu.tsx
@@ -1,6 +1,6 @@
-import { faList, faRss, faHome } from '@fortawesome/free-solid-svg-icons';
 import { IconDefinition } from '@fortawesome/free-brands-svg-icons';
-import cfg from '@/../sbstr8.config';
+import defaults from '@/sbstr8/lib/default';
+import { override } from '@/../sbstr8.config';
 
 export interface MenuItem {
   icon: IconDefinition;
@@ -10,23 +10,8 @@ export interface MenuItem {
   iconic?: boolean;
 }
 
-export const menuLinks = [
-  {
-    href: cfg.link,
-    icon: faHome,
-    title: 'Home',
-  },
-  {
-    href: cfg.postPath,
-    icon: faList,
-    title: 'Posts',
-  },
-  {
-    href: cfg.feedPath,
-    icon: faRss,
-    title: 'RSS Feed',
-    iconic: true,
-  },
-];
+export const menu = override
+  ? override.get(defaults.menu) || defaults.menu
+  : defaults.menu;
 
-export default menuLinks;
+export default menu;

--- a/src/sbstr8/lib/sitemap.ts
+++ b/src/sbstr8/lib/sitemap.ts
@@ -5,7 +5,7 @@ import {
 } from '@/sbstr8/lib/post';
 import cfg from '@/../sbstr8.config';
 import urlJoin from 'url-join';
-import { menuLinks } from '@/sbstr8/lib/menu';
+import { menu, MenuItem } from '@/sbstr8/lib/menu';
 
 export default function sitemap() {
   const posts = getSortedPost();
@@ -15,7 +15,7 @@ export default function sitemap() {
     lastModified: updated || created || new Date().toISOString(),
   }));
   sitemap.push({ url: cfg.link, lastModified });
-  menuLinks.map((ml) => {
+  menu.map((ml: MenuItem) => {
     if (/^(http|mailto).*$/.test(ml.href || '')) {
       return;
     }


### PR DESCRIPTION
I generalized the override mechanism to handle defaults of all kinds, including the default menu, and I made a simple modification to lib/menu.tsx to pull from the override form the menu, if available.

Closes #24 