### PR TITLE
fix(missing links): missing metadata and links in head, also robots.txt

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next';
+import urlJoin from 'url-join';
+import cfg from '@/../sbstr8.config';
+import def from '@/sbstr8/lib/default';
+
+export const robots = (): MetadataRoute.Robots => ({
+  rules: {
+    userAgent: '*',
+    allow: '/',
+    disallow: def.path.private,
+  },
+  sitemap: urlJoin(cfg.link, def.path.sitemap),
+});
+export default robots;

--- a/src/sbstr8/components/layout/root.tsx
+++ b/src/sbstr8/components/layout/root.tsx
@@ -2,6 +2,7 @@ import urlJoin from 'url-join';
 import '@/sbstr8/lib/style.css';
 import pkg from '@/../package.json';
 import cfg, { defaultAuthor } from '@/../sbstr8.config';
+import defaults from '@/sbstr8/lib/default';
 
 const MainLayout = ({ children }: React.PropsWithChildren<unknown>) => (
   <html lang="en" className="sbstr8:layout-root">
@@ -22,6 +23,12 @@ export default MainLayout;
 export const metadata = {
   applicationName: cfg.title,
   authors: cfg.owners.map(({ name, link }) => ({ name, url: link })),
+  alternates: {
+    canonical: cfg.link,
+    types: {
+      'application/rss+xml': urlJoin(cfg.link, defaults.path.feed),
+    },
+  },
   category: cfg.categories.join('/'),
   creator: defaultAuthor.name,
   description: cfg.description,

--- a/src/sbstr8/lib/default.ts
+++ b/src/sbstr8/lib/default.ts
@@ -1,12 +1,21 @@
 import { faList, faRss, faHome } from '@fortawesome/free-solid-svg-icons';
 // Defaults
 
+const feedPath = '/feed';
+const postsPath = '/posts';
+
 export const defaults = {
   menu: [
     { href: '/', title: 'Home', icon: faHome },
-    { href: '/feed', title: 'Feed', icon: faRss },
-    { href: '/posts', title: 'Posts', icon: faList },
+    { href: feedPath, title: 'Feed', icon: faRss },
+    { href: postsPath, title: 'Posts', icon: faList },
   ],
+  path: {
+    feed: feedPath,
+    posts: postsPath,
+    sitemap: '/sitemap.xml',
+    private: '/private',
+  },
   date: {
     created: 'Jan 01 2023',
   },


### PR DESCRIPTION
also missing link to rss and robots.txt.

It turns out that there is currently no means of doing a link to a sitemap in Next13 (see https://github.com/vercel/next.js/issues/52228)

So I added a robots.txt which was missing anyway, and *it* links to the sitemap

closes #43 